### PR TITLE
Add access code gate to Streamlit app

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -9,6 +9,36 @@ from pandas.api.types import is_datetime64_any_dtype
 
 st.set_page_config(page_title="Workbook Viewer", layout="wide")
 
+ACCESS_CODE = "1312"
+
+
+def _require_access_code() -> None:
+    """Prompt for the access code and halt execution until it is validated."""
+
+    if "access_granted" not in st.session_state:
+        st.session_state.access_granted = False
+
+    if st.session_state.access_granted:
+        return
+
+    st.title("Access Restricted")
+
+    with st.form("access_code"):
+        code = st.text_input("Enter access code", type="password")
+        submitted = st.form_submit_button("Submit")
+
+    if submitted:
+        if code == ACCESS_CODE:
+            st.session_state.access_granted = True
+            st.experimental_rerun()
+        else:
+            st.error("Incorrect access code. Please try again.")
+
+    st.stop()
+
+
+_require_access_code()
+
 st.markdown(
     """
     <style>


### PR DESCRIPTION
## Summary
- prompt the user for an access code before displaying the workbook viewer
- block access until the correct code is provided and persist access in the session

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcce55f7b48329a3ea748c6306a8cf