### PR TITLE
Fix access code handling

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -3,13 +3,22 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Iterable
 
+import hashlib
+
 import pandas as pd
 import streamlit as st
 from pandas.api.types import is_datetime64_any_dtype
 
 st.set_page_config(page_title="Workbook Viewer", layout="wide")
 
-ACCESS_CODE = "1312"
+ACCESS_CODE_HASH = "712dca40936b39ce670dc803736fe3735cf99311030a928de039a36f77926230"
+
+
+def _access_code_matches(candidate: str) -> bool:
+    """Return ``True`` when the provided candidate matches the stored code."""
+
+    candidate_hash = hashlib.sha256(candidate.encode("utf-8")).hexdigest()
+    return candidate_hash == ACCESS_CODE_HASH
 
 
 def _require_access_code() -> None:
@@ -28,9 +37,9 @@ def _require_access_code() -> None:
         submitted = st.form_submit_button("Submit")
 
     if submitted:
-        if code == ACCESS_CODE:
+        if _access_code_matches(code):
             st.session_state.access_granted = True
-            st.experimental_rerun()
+            st.rerun()
         else:
             st.error("Incorrect access code. Please try again.")
 


### PR DESCRIPTION
## Summary
- replace the deprecated `st.experimental_rerun` call with `st.rerun` so the form submission succeeds
- store the access code as a SHA-256 hash and verify submissions against it instead of keeping the code in plain text

## Testing
- Not run (streamlit app)


------
https://chatgpt.com/codex/tasks/task_e_68dccf6155288329bf29ad9f3d1714ae